### PR TITLE
Correct GPIO name for Pico-6ul

### DIFF
--- a/audio-sink/src/main/java/com/example/androidthings/bluetooth/audio/BoardDefaults.java
+++ b/audio-sink/src/main/java/com/example/androidthings/bluetooth/audio/BoardDefaults.java
@@ -68,7 +68,7 @@ public class BoardDefaults {
             case DEVICE_RPI3:
                 return "BCM20";
             case DEVICE_PICO:
-                return "GPIO4_IO18";
+                return "GPIO1_IO18";
             case DEVICE_VVDN:
                 return "GPIO3_IO06";
             default:


### PR DESCRIPTION
Pico-6ul use GPIO1_IO18 instead of
GPIO4_IO18. Or the APP will cause
exception when try to access GPIO.

Signed-off-by: Haoran Wang <elven.wang@nxp.com>